### PR TITLE
After perform hooks

### DIFF
--- a/app/models/approval/item.rb
+++ b/app/models/approval/item.rb
@@ -27,6 +27,10 @@ module Approval
       send("exec_#{event}")
     end
 
+    def after_apply
+      exec_after_perform if event == "perform"
+    end
+
     private
 
       def exec_create
@@ -54,6 +58,16 @@ module Approval
           resource_model.perform(params)
         else
           resource_model.perform
+        end
+      end
+
+      def exec_after_perform
+        return unless resource_model.respond_to?(:after_perform)
+
+        if resource_model.method(:after_perform).arity > 0
+          resource_model.after_perform(params)
+        else
+          resource_model.after_perform
         end
       end
 

--- a/app/models/approval/request.rb
+++ b/app/models/approval/request.rb
@@ -29,7 +29,7 @@ module Approval
     end
 
     after_commit(on: :update) do
-      if self.previous_changes["state"][0] != "executed" && self.previous_changes["state"][1] == "executed"
+      if state_previously_changed? && executed?
         items.each(&:after_apply)
       end
     end

--- a/app/models/approval/request.rb
+++ b/app/models/approval/request.rb
@@ -28,6 +28,12 @@ module Approval
       self.requested_at = Time.current
     end
 
+    after_commit(on: :update) do
+      if self.previous_changes["state"][0] != "executed" && self.previous_changes["state"][1] == "executed"
+        items.each(&:after_apply)
+      end
+    end
+
     def execute
       self.state = :executed
       self.executed_at = Time.current


### PR DESCRIPTION
```ruby
class PerformItem
  def perform
    # executed inside ExecuteForm or RespondForm::ApproveWithExecute transactions
  end
  def after_perform
    # executed outside ExecuteForm or RespondForm::ApproveWithExecute transactions
  end
end
```

Relies on `respond_to?(:after_perform)` because existing code relies on `respond_to?(:perform)` and defining any modules would be a breaking change.